### PR TITLE
feat: record patient consent and integrate turborepo

### DIFF
--- a/apps/patient-web/src/config/api.ts
+++ b/apps/patient-web/src/config/api.ts
@@ -15,6 +15,9 @@ export const API_CONFIG = {
       MESSAGE: '/chat/message',
       SESSION_NEW: '/chat/session/new',
       CHEMO_LOG: '/chemo/log'
+    },
+    PATIENT: {
+      UPDATE_CONSENT: '/patient/update-consent'
     }
   }
 };

--- a/apps/patient-web/src/pages/LoginPage/Acknowledgement.tsx
+++ b/apps/patient-web/src/pages/LoginPage/Acknowledgement.tsx
@@ -1,9 +1,27 @@
 import logo from '../../assets/logo.png';
-import React from 'react';
+import React, { useState } from 'react';
 import { Background, WrapperStyle, Logo, Card } from '@oncolife/ui-components';
 import { MainContent, StyledButton, LoginTitle, LoginHeader } from './LoginPage.styles';
+import { useNavigate } from 'react-router-dom';
+import { patientService } from '../../services/patient';
 
 const Acknowledgement: React.FC<{ onAgree?: () => void }> = ({ onAgree }) => {
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleAgree = async () => {
+    try {
+      setSubmitting(true);
+      await patientService.updateConsent();
+      onAgree?.();
+      navigate('/chat');
+    } catch (error) {
+      console.error('Failed to update consent acknowledgement:', error);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <Background>
         <WrapperStyle>
@@ -32,8 +50,8 @@ const Acknowledgement: React.FC<{ onAgree?: () => void }> = ({ onAgree }) => {
                         Sincerely,<br />
                         The OncoLife AI Team
                     </p>
-                    <StyledButton variant="primary" type="button" onClick={onAgree}>
-                        I Agree
+                    <StyledButton variant="primary" type="button" onClick={handleAgree} disabled={submitting}>
+                        {submitting ? 'Processing...' : 'I Agree'}
                     </StyledButton>
                 </Card>
             </MainContent>

--- a/apps/patient-web/src/services/chatService.ts
+++ b/apps/patient-web/src/services/chatService.ts
@@ -1,91 +1,38 @@
 import { getUserTimezone } from '@oncolife/shared-utils';
-
-const API_BASE = '/api/chat';
+import { apiClient } from '../utils/apiClient';
+import { API_CONFIG } from '../config/api';
 
 export const chatService = {
   getTodaySession: async () => {
-    const token = localStorage.getItem('authToken');
     const timezone = getUserTimezone();
-    try {
-      const response = await fetch(`${API_BASE}/session/today?timezone=${encodeURIComponent(timezone)}`, {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch chat session');
-      }
-
-      const data = await response.json();
-      return { success: true, status: response.status, data };
-    } catch (error) {
-      console.error('Failed to fetch chat session:', error);
-      throw error;
-    }
+    const response = await apiClient.get(
+      `${API_CONFIG.ENDPOINTS.CHAT.SESSION_TODAY}?timezone=${encodeURIComponent(timezone)}`
+    );
+    return { success: true, status: response.status, data: response.data };
   },
 
   sendMessage: async (chatUuid: string, content: string) => {
-    const token = localStorage.getItem('authToken');
-    const response = await fetch(`${API_BASE}/message`, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ chat_uuid: chatUuid, content })
+    const response = await apiClient.post(API_CONFIG.ENDPOINTS.CHAT.MESSAGE, {
+      chat_uuid: chatUuid,
+      content,
     });
-    return response.json();
+    return response.data;
   },
 
   startNewSession: async () => {
-    const token = localStorage.getItem('authToken');
     const timezone = getUserTimezone();
-    const response = await fetch(`${API_BASE}/session/new?timezone=${encodeURIComponent(timezone)}`, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-      }
-    });
-    if (!response.ok) {
-      throw new Error('Failed to start a new chat session');
-    }
-    const data = await response.json();
-    return data;
+    const response = await apiClient.post(
+      `${API_CONFIG.ENDPOINTS.CHAT.SESSION_NEW}?timezone=${encodeURIComponent(timezone)}`
+    );
+    return response.data;
   },
 
   logChemoDate: async (chemoDate: Date) => {
-    const token = localStorage.getItem('authToken');
     const timezone = getUserTimezone();
-    try {
-      const response = await fetch(`${API_BASE}/chemo/log`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          chemo_date: chemoDate.toISOString().split('T')[0],
-          timezone: timezone
-        })
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error('Response error:', errorText);
-        throw new Error('Failed to log chemotherapy date');
-      }
-
-      const result = await response.json();
-      if (result.error || result.success === false) {
-        throw new Error(result.error?.details || 'Failed to log chemotherapy date');
-      }
-
-      return result;
-    } catch (error) {
-      console.error('Fetch error:', error);
-      throw error;
-    }
-  }
+    const response = await apiClient.post(API_CONFIG.ENDPOINTS.CHAT.CHEMO_LOG, {
+      chemo_date: chemoDate.toISOString().split('T')[0],
+      timezone,
+    });
+    return response.data;
+  },
 };

--- a/apps/patient-web/src/services/patient.ts
+++ b/apps/patient-web/src/services/patient.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '../utils/apiClient';
+import { API_CONFIG } from '../config/api';
+
+export const patientService = {
+  updateConsent: async () => {
+    const response = await apiClient.patch(API_CONFIG.ENDPOINTS.PATIENT.UPDATE_CONSENT, {
+      agreed_conditions: true,
+      acknowledgement_done: true,
+    });
+    return response.data;
+  },
+};
+

--- a/package.json
+++ b/package.json
@@ -7,15 +7,17 @@
     "packages/*"
   ],
   "scripts": {
-    "dev:patient": "concurrently \"npm run dev --workspace=@oncolife/patient-web\" \"npm run dev --workspace=@oncolife/patient-server\"",
-    "dev:doctor": "npm run dev --workspace=@oncolife/doctor-web & npm run dev --workspace=@oncolife/doctor-api",
-    "build:all": "npm run build --workspaces",
-    "build:patient": "npm run build --workspace=@oncolife/patient-web && npm run build:docker --workspace=@oncolife/patient-api",
-    "build:doctor": "npm run build --workspace=@oncolife/doctor-web && npm run build:docker --workspace=@oncolife/doctor-api",
+    "dev": "turbo run dev --parallel",
+    "dev:patient": "turbo run dev --parallel --filter=@oncolife/patient-web --filter=@oncolife/patient-server",
+    "dev:doctor": "turbo run dev --parallel --filter=@oncolife/doctor-web --filter=@oncolife/doctor-api",
+    "build:all": "turbo run build",
+    "build:patient": "turbo run build --filter=@oncolife/patient-web --filter=@oncolife/patient-api",
+    "build:doctor": "turbo run build --filter=@oncolife/doctor-web --filter=@oncolife/doctor-api",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules"
   },
   "devDependencies": {
     "concurrently": "^8.2.0",
+    "turbo": "^1.10.12",
     "typescript": "^5.3.0"
   },
   "engines": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**"]
+    },
+    "dev": {
+      "cache": false
+    },
+    "lint": {
+      }
+  }
+}


### PR DESCRIPTION
## Summary
- record patient consent before entering chat
- centralize auth token handling in chat API service
- add turborepo config and scripts for workspace builds

## Testing
- `npm install --ignore-scripts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/turbo)*
- `npm run lint --workspace=@oncolife/patient-web` *(fails: existing ESLint errors)*
- `npm run build --workspace=@oncolife/patient-web` *(fails: TS6133 in packages/ui-components)*
- `npm test` *(fails: missing script)*


------
https://chatgpt.com/codex/tasks/task_e_6895ad518594833194e5794e0bee4a51